### PR TITLE
Badge border radius.

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -48,7 +48,7 @@ const updateBadgesForAllUsers = () => {
                         description: badge.description,
                         props: {
                             style: {
-                                borderRadius: "5%",
+                                borderRadius: "15%",
                                 transform: "scale(0.9)"
                             }
                         },

--- a/index.tsx
+++ b/index.tsx
@@ -48,7 +48,7 @@ const updateBadgesForAllUsers = () => {
                         description: badge.description,
                         props: {
                             style: {
-                                borderRadius: "50%",
+                                borderRadius: "5%",
                                 transform: "scale(0.9)"
                             }
                         },


### PR DESCRIPTION
There was an update of border radius for badge: https://github.com/sampathgujarathi/fakeProfile/commit/76bb9d71762ceb0667ab8e84291dd7205cfcaee6#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722b

But after fixes for simplified profile it was reverted to `50%` instead of `15%`